### PR TITLE
faster str_splite

### DIFF
--- a/nginx/app/src/modules/utils.lua
+++ b/nginx/app/src/modules/utils.lua
@@ -2,6 +2,7 @@ local str_sub     = string.sub
 local str_gsub    = string.gsub
 local str_find    = string.find
 local str_match   = string.match
+local str_gmatch  = string.gmatch
 local str_byte    = string.byte
 local str_reverse = string.reverse
 local tab_insert  = table.insert
@@ -11,25 +12,16 @@ local tab_sort    = table.sort
 local _M = {}
 
 
-function _M.str_split(str, split_char)
-    local sub_str_tab = {}
-    local i, j = 0, 0
-    local ss
-    while true do
-        j = str_find(str, split_char, i + 1, true)
-        if not j then
-            j = #str + 1
-        end
-        ss = str_sub(str, i + 1, j - 1)
-        if #ss > 0 then
-            tab_insert(sub_str_tab, ss)
-        end
-        if j >= #str then
-            break
-        end
-        i = j
+function _M.str_split(str, sep)
+    if not sep then
+        sep = "%s"
     end
-    return sub_str_tab
+    local res = {}, i = 1
+    for ss in str_gmatch(str, "([^" .. sep .. "]+)") do
+        res[i] = ss
+        i = i + 1
+    end
+    return res
 end
 
 

--- a/nginx/app/src/modules/utils.lua
+++ b/nginx/app/src/modules/utils.lua
@@ -16,7 +16,8 @@ function _M.str_split(str, sep)
     if not sep then
         sep = "%s"
     end
-    local res = {}, i = 1
+    local res = {}
+    local i = 1
     for ss in str_gmatch(str, "([^" .. sep .. "]+)") do
         res[i] = ss
         i = i + 1


### PR DESCRIPTION
hello
对比了下之前str_splite和现在的str_splite的性能：

```
local str = "hello,world,o ojid, jiadej,,, jidjie, jiajd, jiejd ,,jjie" 
local str = string.rep(str, 100) 
local res 
for i = 1, 100000, 1 do   
    res = str_split(str, ",")  
end

````

如果是之前的str_splite,结果：
time lua test.lua 
real    0m40.556s                                                                                               
user    0m40.285s                                                                                 
sys     0m0.004s  

替换后：
time lua test.lua 
real    0m24.232s
user    0m24.067s
sys     0m0.003s

差距还是挺大的，gmatch性能更好。